### PR TITLE
updated link to pre-trained imagenet models

### DIFF
--- a/data/scripts/fetch_imagenet_models.sh
+++ b/data/scripts/fetch_imagenet_models.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 cd $DIR
 
 FILE=imagenet_models.tgz
-URL=http://www.cs.berkeley.edu/~rbg/faster-rcnn-data/$FILE
+URL=https://dl.dropbox.com/s/gstw7122padlf0l/imagenet_models.tgz?dl=0
 CHECKSUM=ed34ca912d6782edfb673a8c3a0bda6d
 
 if [ -f $FILE ]; then


### PR DESCRIPTION
Updated the link to pre-trained imagenet models as updated in the py-faster-rcnn repo. The previous link is broken.